### PR TITLE
chore: add tailwind source as project root

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,4 @@
-@import 'tailwindcss';
+@import 'tailwindcss' source("../");
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,4 @@
-@import 'tailwindcss' source("../");
+@import 'tailwindcss' source('../');
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
Tailwind V4 use new auto-dectection configuration system. It take vite root path as tailwind root path so if you don't override the root it will not take in account the src folder and so shadcn components folder/