### PR TITLE
feat: avatar

### DIFF
--- a/demo/src/routes.ts
+++ b/demo/src/routes.ts
@@ -14,6 +14,12 @@ const routes: Array<RouteRecord> = [
     component: () => import('@demo/views/Breadcrumb.vue'),
     menuLabel: 'Breadcrumb',
   }),
+  createRoute({
+    path: '/avatar',
+    name: 'avatar',
+    component: () => import('@demo/views/Avatar.vue'),
+    menuLabel: 'Avatar',
+  }),
   // Catch all unmatched routes
   createRoute({
     path: '/:pathMatch(.*)*',

--- a/demo/src/views/Avatar.vue
+++ b/demo/src/views/Avatar.vue
@@ -3,7 +3,7 @@
   <p class="mb-3">not square :</p>
   <Avatar class="mb-3" :data="dataUser" />
   <p class="mb-3">square :</p>
-  <Avatar class="mb-3" :data="dataUser" :is-square="true" :bg-color="'#ff0000'"/>
+  <Avatar class="mb-3" :data="dataUser" :is-square="true" :bg-color="'#ff0000'" />
 </template>
 
 <script setup lang="ts">
@@ -17,6 +17,4 @@ const dataUser = {
 };
 </script>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/demo/src/views/Avatar.vue
+++ b/demo/src/views/Avatar.vue
@@ -3,7 +3,7 @@
   <p class="mb-3">not square :</p>
   <Avatar class="mb-3" :data="dataUser" />
   <p class="mb-3">square :</p>
-  <Avatar class="mb-3" :data="dataUser" :isSquare="true" />
+  <Avatar class="mb-3" :data="dataUser" :is-square="true" :bg-color="'#ff0000'"/>
 </template>
 
 <script setup lang="ts">
@@ -13,6 +13,10 @@ const dataUser = {
   name: 'Alice',
   email: 'alice@example.com',
   avatar:
-    'https://st5.depositphotos.com/1001941/66147/v/450/depositphotos_661475956-stock-illustration-anonymous-hacker-using-laptop-desk.jpg',
+    'https://avataaars.io/?avatarStyle=Transparent&topType=NoHair&accessoriesType=Blank&facialHairType=MoustacheFancy&facialHairColor=BrownDark&clotheType=ShirtScoopNeck&clotheColor=Blue03&eyeType=Default&eyebrowType=DefaultNatural&mouthType=Smile&skinColor=Light',
 };
 </script>
+
+<style scoped>
+
+</style>

--- a/demo/src/views/Avatar.vue
+++ b/demo/src/views/Avatar.vue
@@ -1,11 +1,15 @@
 <template>
-  <h1 class="mb-3">AVATAR :</h1>
-  <p class="mb-3">not square :</p>
-  <Avatar class="mb-3" :url="avatar_url" />
-  <p class="mb-3">square :</p>
-  <Avatar class="mb-3" :url="avatar_url" :is-square="true" :bg-color="'#ff0000'" />
-  <p class="mb-3">without avatar :</p>
-  <Avatar class="mb-3" :bg-color="'#ff00ff'" />
+  <div class="p-5">
+    <h1 class="mb-3">AVATAR :</h1>
+    <p class="mb-3">not square :</p>
+    <Avatar class="mb-3" :url="avatar_url" />
+    <p class="mb-3">square :</p>
+    <Avatar class="mb-3" :url="avatar_url" :is-square="true" :bg-color="'#ff0000'" />
+    <p class="mb-3">without avatar :</p>
+    <Avatar class="mb-3" :bg-color="'#ff00ff'" />
+    <p class="mb-3">without avatar with initials :</p>
+    <Avatar class="mb-3" :bg-color="'#000000'" :text-color="'#ff00ff'" :initials="'ab'" />
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/demo/src/views/Avatar.vue
+++ b/demo/src/views/Avatar.vue
@@ -1,20 +1,18 @@
 <template>
   <h1 class="mb-3">AVATAR :</h1>
   <p class="mb-3">not square :</p>
-  <Avatar class="mb-3" :data="dataUser" />
+  <Avatar class="mb-3" :url="avatar_url" />
   <p class="mb-3">square :</p>
-  <Avatar class="mb-3" :data="dataUser" :is-square="true" :bg-color="'#ff0000'" />
+  <Avatar class="mb-3" :url="avatar_url" :is-square="true" :bg-color="'#ff0000'" />
+  <p class="mb-3">without avatar :</p>
+  <Avatar class="mb-3" :bg-color="'#ff00ff'" />
 </template>
 
 <script setup lang="ts">
 import Avatar from '@/components/avatar/Avatar.vue';
 
-const dataUser = {
-  name: 'Alice',
-  email: 'alice@example.com',
-  avatar:
-    'https://avataaars.io/?avatarStyle=Transparent&topType=NoHair&accessoriesType=Blank&facialHairType=MoustacheFancy&facialHairColor=BrownDark&clotheType=ShirtScoopNeck&clotheColor=Blue03&eyeType=Default&eyebrowType=DefaultNatural&mouthType=Smile&skinColor=Light',
-};
+const avatar_url =
+  'https://avataaars.io/?avatarStyle=Transparent&topType=NoHair&accessoriesType=Blank&facialHairType=MoustacheFancy&facialHairColor=BrownDark&clotheType=ShirtScoopNeck&clotheColor=Blue03&eyeType=Default&eyebrowType=DefaultNatural&mouthType=Smile&skinColor=Light';
 </script>
 
 <style scoped></style>

--- a/demo/src/views/Avatar.vue
+++ b/demo/src/views/Avatar.vue
@@ -1,0 +1,18 @@
+<template>
+  <h1 class="mb-3">AVATAR :</h1>
+  <p class="mb-3">not square :</p>
+  <Avatar class="mb-3" :data="dataUser" />
+  <p class="mb-3">square :</p>
+  <Avatar class="mb-3" :data="dataUser" :isSquare="true" />
+</template>
+
+<script setup lang="ts">
+import Avatar from '@/components/avatar/Avatar.vue';
+
+const dataUser = {
+  name: 'Alice',
+  email: 'alice@example.com',
+  avatar:
+    'https://st5.depositphotos.com/1001941/66147/v/450/depositphotos_661475956-stock-illustration-anonymous-hacker-using-laptop-desk.jpg',
+};
+</script>

--- a/src/components/avatar/Avatar.vue
+++ b/src/components/avatar/Avatar.vue
@@ -1,7 +1,12 @@
 <template>
   <ShadcnAvatar :class="props.isSquare ? 'h-8 w-8 rounded-lg' : ''" :style="{ backgroundColor: props.bgColor }">
     <ShadcnAvatarImage :src="props.url ?? ''" alt="Avatar" />
-    <ShadcnAvatarFallback :style="{ backgroundColor: props.bgColor }">?</ShadcnAvatarFallback>
+    <ShadcnAvatarFallback :style="{ backgroundColor: props.bgColor, color: props.textColor }">
+      <span v-if="props.initials" class="text-md font-bold">
+        {{ props.initials.toUpperCase() }}
+      </span>
+      <span v-else>?</span>
+    </ShadcnAvatarFallback>
   </ShadcnAvatar>
 </template>
 
@@ -14,13 +19,18 @@ import {
 } from '@/shadcn/ui/avatar';
 
 const props = defineProps({
-  isSquare: {
-    type: Boolean,
-    default: false,
-  },
   url: {
     type: String,
     required: false,
+  },
+  initials: {
+    type: String,
+    required: false,
+    validator: (value: string | null): boolean => {
+      if (value === null) return true;
+      // Check if the value is a string of 1 or 2 letters
+      return /^[a-zA-Z]{1,2}$/.test(value);
+    }
   },
   bgColor: {
     type: String as PropType<string | null>,
@@ -30,6 +40,19 @@ const props = defineProps({
       if (value === null) return true;
       return /^#([0-9A-F]{3}){1,2}$/i.test(value);
     },
+  },
+  textColor: {
+    type: String as PropType<string | null>,
+    required: false,
+    default: null,
+    validator: (value: string | null): boolean => {
+      if (value === null) return true;
+      return /^#([0-9A-F]{3}){1,2}$/i.test(value);
+    },
+  },
+  isSquare: {
+    type: Boolean,
+    default: false,
   },
 });
 </script>

--- a/src/components/avatar/Avatar.vue
+++ b/src/components/avatar/Avatar.vue
@@ -1,0 +1,26 @@
+<template>
+  <ShadcnAvatar :class="props.isSquare ? 'h-8 w-8 rounded-lg' : ''">
+    <ShadcnAvatarImage :src="data.avatar" :alt="data.name" />
+    <ShadcnAvatarFallback>?</ShadcnAvatarFallback>
+  </ShadcnAvatar>
+</template>
+
+<script setup lang="ts">
+import { defineProps } from 'vue';
+import {
+  Avatar as ShadcnAvatar,
+  AvatarImage as ShadcnAvatarImage,
+  AvatarFallback as ShadcnAvatarFallback,
+} from '@/shadcn/ui/avatar';
+
+const props = defineProps({
+  isSquare: {
+    type: Boolean,
+    default: false,
+  },
+  data: {
+    type: Object,
+    required: true,
+  },
+});
+</script>

--- a/src/components/avatar/Avatar.vue
+++ b/src/components/avatar/Avatar.vue
@@ -1,12 +1,15 @@
 <template>
-  <ShadcnAvatar :class="props.isSquare ? 'h-8 w-8 rounded-lg' : ''">
-    <ShadcnAvatarImage :src="data.avatar" :alt="data.name" />
+  <ShadcnAvatar
+    :class="props.isSquare ? 'h-8 w-8 rounded-lg' : ''"
+    :style="{ backgroundColor: props.bgColor }"
+  >
+    <ShadcnAvatarImage :src="props.data.avatar" :alt="props.data.name" />
     <ShadcnAvatarFallback>?</ShadcnAvatarFallback>
   </ShadcnAvatar>
 </template>
 
 <script setup lang="ts">
-import { defineProps } from 'vue';
+import { defineProps, type PropType } from 'vue';
 import {
   Avatar as ShadcnAvatar,
   AvatarImage as ShadcnAvatarImage,
@@ -22,5 +25,16 @@ const props = defineProps({
     type: Object,
     required: true,
   },
+  bgColor: {
+    type: String as PropType<string | null>,
+    required: false,
+    default: null,
+    validator: (value: string | null): boolean => {
+      // Allow null values
+      if (value === null) return true;
+      // Validate that the string is a valid hex color
+      return /^#([0-9A-F]{3}){1,2}$/i.test(value);
+    }
+  }
 });
 </script>

--- a/src/components/avatar/Avatar.vue
+++ b/src/components/avatar/Avatar.vue
@@ -1,8 +1,5 @@
 <template>
-  <ShadcnAvatar
-    :class="props.isSquare ? 'h-8 w-8 rounded-lg' : ''"
-    :style="{ backgroundColor: props.bgColor }"
-  >
+  <ShadcnAvatar :class="props.isSquare ? 'h-8 w-8 rounded-lg' : ''" :style="{ backgroundColor: props.bgColor }">
     <ShadcnAvatarImage :src="props.data.avatar" :alt="props.data.name" />
     <ShadcnAvatarFallback>?</ShadcnAvatarFallback>
   </ShadcnAvatar>
@@ -34,7 +31,7 @@ const props = defineProps({
       if (value === null) return true;
       // Validate that the string is a valid hex color
       return /^#([0-9A-F]{3}){1,2}$/i.test(value);
-    }
-  }
+    },
+  },
 });
 </script>

--- a/src/components/avatar/Avatar.vue
+++ b/src/components/avatar/Avatar.vue
@@ -1,7 +1,7 @@
 <template>
   <ShadcnAvatar :class="props.isSquare ? 'h-8 w-8 rounded-lg' : ''" :style="{ backgroundColor: props.bgColor }">
-    <ShadcnAvatarImage :src="props.data.avatar" :alt="props.data.name" />
-    <ShadcnAvatarFallback>?</ShadcnAvatarFallback>
+    <ShadcnAvatarImage :src="props.url ?? ''" alt="Avatar" />
+    <ShadcnAvatarFallback :style="{ backgroundColor: props.bgColor }">?</ShadcnAvatarFallback>
   </ShadcnAvatar>
 </template>
 
@@ -18,18 +18,16 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  data: {
-    type: Object,
-    required: true,
+  url: {
+    type: String,
+    required: false,
   },
   bgColor: {
     type: String as PropType<string | null>,
     required: false,
     default: null,
     validator: (value: string | null): boolean => {
-      // Allow null values
       if (value === null) return true;
-      // Validate that the string is a valid hex color
       return /^#([0-9A-F]{3}){1,2}$/i.test(value);
     },
   },

--- a/src/shadcn/ui/avatar/Avatar.vue
+++ b/src/shadcn/ui/avatar/Avatar.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/shadcn/lib/utils'
+import { AvatarRoot } from 'reka-ui'
+
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+</script>
+
+<template>
+  <AvatarRoot
+    data-slot="avatar"
+    :class="cn('relative flex size-8 shrink-0 overflow-hidden rounded-full', props.class)"
+  >
+    <slot />
+  </AvatarRoot>
+</template>

--- a/src/shadcn/ui/avatar/AvatarFallback.vue
+++ b/src/shadcn/ui/avatar/AvatarFallback.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { cn } from '@/shadcn/lib/utils'
+import { AvatarFallback, type AvatarFallbackProps } from 'reka-ui'
+import { computed, type HTMLAttributes } from 'vue'
+
+const props = defineProps<AvatarFallbackProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+</script>
+
+<template>
+  <AvatarFallback
+    data-slot="avatar-fallback"
+    v-bind="delegatedProps"
+    :class="cn('bg-muted flex size-full items-center justify-center rounded-full', props.class)"
+  >
+    <slot />
+  </AvatarFallback>
+</template>

--- a/src/shadcn/ui/avatar/AvatarImage.vue
+++ b/src/shadcn/ui/avatar/AvatarImage.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import type { AvatarImageProps } from 'reka-ui'
+import { AvatarImage } from 'reka-ui'
+
+const props = defineProps<AvatarImageProps>()
+</script>
+
+<template>
+  <AvatarImage
+    data-slot="avatar-image"
+    v-bind="props"
+    class="aspect-square size-full"
+  >
+    <slot />
+  </AvatarImage>
+</template>

--- a/src/shadcn/ui/avatar/index.ts
+++ b/src/shadcn/ui/avatar/index.ts
@@ -1,0 +1,3 @@
+export { default as Avatar } from './Avatar.vue'
+export { default as AvatarFallback } from './AvatarFallback.vue'
+export { default as AvatarImage } from './AvatarImage.vue'


### PR DESCRIPTION
An Avatar component that displays a user’s profile picture. You can toggle between a circular or square avatar using the `isSquare` prop.

To use it, pass the `data` prop with user details and set `isSquare` to `true` for a square avatar.

You can also customize the background color using the `bgColor` prop (hex value, e.g. `#ff0000`).

Here's an example render with a profile picture from https://getavataaars.com/

![image](https://github.com/user-attachments/assets/2ed40b59-5350-4b97-9463-bb28554d5698)

