### PR TITLE
fix: set off multi-word-component-names eslint rule

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -10,10 +10,15 @@ export default defineConfigWithVueTs(
   },
   {
     name: 'app/files-to-ignore',
-    ignores: ['/dist/**', '/src/shadcn/**'],
+    ignores: ['dist/**', 'src/shadcn/**'],
   },
   globalIgnores(['dist/**', '/src/shadcn/**']),
   pluginVue.configs['flat/essential'],
   vueTsConfigs.recommended,
-  skipFormatting
+  skipFormatting,
+  {
+    rules: {
+      'vue/multi-word-component-names': 'off',
+    },
+  }
 );


### PR DESCRIPTION
This PR set off `vue/multi-word-component-names` eslint rule