### PR TITLE
feat: accordion

### DIFF
--- a/demo/src/routes.ts
+++ b/demo/src/routes.ts
@@ -92,6 +92,14 @@ const routes: RouteRecordRaw[] = [
       menuLabel: 'Toaster',
     },
   }),
+  createRoute({
+    path: '/accordion',
+    name: 'accordion',
+    component: () => import('@/views/Accordion.vue'),
+    meta: {
+      menuLabel: 'Accordion',
+    },
+  }),
   // Catch all unmatched routes
   createRoute({
     path: '/:pathMatch(.*)*',

--- a/demo/src/views/Accordion.vue
+++ b/demo/src/views/Accordion.vue
@@ -1,51 +1,94 @@
 <template>
   <div class="p-5">
     <div>
-      <h1 class="mb-3">Single Accordion :</h1>
-      <Accordion :items="items" />
+      <h1 class="mt-10 mb-3">Accordion Single :</h1>
+      <Accordion>
+        <AccordionItem value="item-1">
+          <template #title>
+            <span>Accordion 1</span>
+          </template>
+
+          <p>Content 1</p>
+        </AccordionItem>
+
+        <AccordionItem value="item-2">
+          <template #title>
+            <span>Accordion 2</span>
+          </template>
+
+          <p>Content 2</p>
+        </AccordionItem>
+
+        <AccordionItem value="item-3">
+          <template #title>
+            <span>Accordion 3</span>
+          </template>
+
+            <p>Content 3</p>
+        </AccordionItem>
+      </Accordion>
     </div>
+
     <div>
-      <h1 class="mt-10 mb-3">Single Accordion with Collapsible :</h1>
-      <Accordion :items="items" :collapsible="true" />
+      <h1 class="mt-10 mb-3">Accordion Single with collapsible :</h1>
+      <Accordion :collapsible="true">
+        <AccordionItem value="item-1">
+          <template #title>
+            <span>Accordion 1</span>
+          </template>
+
+          <p>Content 1</p>
+        </AccordionItem>
+
+        <AccordionItem value="item-2">
+          <template #title>
+            <span>Accordion 2</span>
+          </template>
+
+          <p>Content 2</p>
+        </AccordionItem>
+
+        <AccordionItem value="item-3">
+          <template #title>
+            <span>Accordion 3</span>
+          </template>
+
+            <p>Content 3</p>
+        </AccordionItem>
+      </Accordion>
     </div>
+
     <div>
-      <h1 class="mt-10 mb-3">Multiple Accordion :</h1>
-      <Accordion :items="items" :multiple="true" />
+      <h1 class="mt-10 mb-3">Accordion Multiple :</h1>
+      <Accordion :multiple="true">
+        <AccordionItem value="item-1">
+          <template #title>
+            <span>Accordion 1</span>
+          </template>
+
+          <p>Content 1</p>
+        </AccordionItem>
+
+        <AccordionItem value="item-2">
+          <template #title>
+            <span>Accordion 2</span>
+          </template>
+
+           <p>Content 2</p>
+        </AccordionItem>
+
+        <AccordionItem value="item-3">
+          <template #title>
+            <span>Accordion 3</span>
+          </template>
+
+            <p>Content 3</p>
+        </AccordionItem>
+      </Accordion>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { Accordion } from '@geonative/ui/components';
-import type { AccordionItem } from '@geonative/ui/types/accordion';
-
-const items: AccordionItem[] = [
-  {
-    label: 'Item 1',
-    content: 'Content for item 1',
-    iconProps: { name: 'star', source: 'heroicons', type: 'solid', class: 'h-4 w-4' },
-    items: [
-      {
-        label: 'Item 1.1',
-        content: 'Content for item 1.1',
-        iconProps: { name: 'bolt', source: 'heroicons', type: 'outline', class: 'h-4 w-4' },
-      },
-      {
-        label: 'Item 1.2',
-        content: 'Content for item 1.2',
-        iconProps: { name: 'bolt', source: 'heroicons', type: 'outline', class: 'h-4 w-4' },
-      },
-    ],
-  },
-  {
-    label: 'Item 2',
-    content: 'Content for item 2',
-    iconProps: { name: 'star', source: 'heroicons', type: 'solid', class: 'h-4 w-4' },
-  },
-  {
-    label: 'Item 3',
-    content: 'Content for item 3',
-    iconProps: { name: 'star', source: 'heroicons', type: 'solid', class: 'h-4 w-4' },
-  },
-];
+import { Accordion, AccordionItem } from '@geonative/ui/components';
 </script>

--- a/demo/src/views/Accordion.vue
+++ b/demo/src/views/Accordion.vue
@@ -5,26 +5,30 @@
       <Accordion>
         <AccordionItem value="item-1">
           <template #title>
-            <span>Accordion 1</span>
+            <div>
+              <Icon name="AlertCircle" source="lucide" class="text-pink-700" />
+            </div>
           </template>
 
-          <p>Content 1</p>
+          <p>this is an alert icon</p>
         </AccordionItem>
 
         <AccordionItem value="item-2">
           <template #title>
-            <span>Accordion 2</span>
+            <div>
+              <Icon name="antenna" source="svg" class="size-7 fill-blue-500" />
+            </div>
           </template>
 
-          <p>Content 2</p>
+          <span>this is an antenna icon</span>
         </AccordionItem>
 
         <AccordionItem value="item-3">
           <template #title>
-            <span>Accordion 3</span>
+            <span>Click to show a Button</span>
           </template>
 
-            <p>Content 3</p>
+          <Button class="bg-green-500">Button</Button>
         </AccordionItem>
       </Accordion>
     </div>
@@ -90,5 +94,5 @@
 </template>
 
 <script setup lang="ts">
-import { Accordion, AccordionItem } from '@geonative/ui/components';
+import { Accordion, AccordionItem, Icon, Button } from '@geonative/ui/components';
 </script>

--- a/demo/src/views/Accordion.vue
+++ b/demo/src/views/Accordion.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="p-5">
+    <div>
+      <h1 class="mb-3">Single Accordion :</h1>
+      <Accordion :items="items" />
+    </div>
+    <div>
+      <h1 class="mt-10 mb-3">Single Accordion with Collapsible :</h1>
+      <Accordion :items="items" :collapsible="true" />
+    </div>
+    <div>
+      <h1 class="mt-10 mb-3">Multiple Accordion :</h1>
+      <Accordion :items="items" :multiple="true" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Accordion } from '@geonative/ui/components';
+import type { AccordionItem } from '@geonative/ui/types/accordion';
+
+const items: AccordionItem[] = [
+  {
+    label: 'Item 1',
+    content: 'Content for item 1',
+    iconProps: { name: 'star', source: 'heroicons', type: 'solid', class: 'h-4 w-4' },
+  },
+  {
+    label: 'Item 2',
+    content: 'Content for item 2',
+    iconProps: { name: 'star', source: 'heroicons', type: 'solid', class: 'h-4 w-4' },
+  },
+  {
+    label: 'Item 3',
+    content: 'Content for item 3',
+    iconProps: { name: 'star', source: 'heroicons', type: 'solid', class: 'h-4 w-4' },
+  },
+];
+</script>

--- a/demo/src/views/Accordion.vue
+++ b/demo/src/views/Accordion.vue
@@ -24,6 +24,18 @@ const items: AccordionItem[] = [
     label: 'Item 1',
     content: 'Content for item 1',
     iconProps: { name: 'star', source: 'heroicons', type: 'solid', class: 'h-4 w-4' },
+    items : [
+      {
+        label: 'Item 1.1',
+        content: 'Content for item 1.1',
+        iconProps: { name: 'bolt', source: 'heroicons', type: 'outline', class: 'h-4 w-4' },
+      },
+      {
+        label: 'Item 1.2',
+        content: 'Content for item 1.2',
+        iconProps: { name: 'bolt', source: 'heroicons', type: 'outline', class: 'h-4 w-4' },
+      },
+    ],
   },
   {
     label: 'Item 2',

--- a/demo/src/views/Accordion.vue
+++ b/demo/src/views/Accordion.vue
@@ -57,7 +57,7 @@
             <span>Accordion 3</span>
           </template>
 
-            <p>Content 3</p>
+          <p>Content 3</p>
         </AccordionItem>
       </Accordion>
     </div>
@@ -78,7 +78,7 @@
             <span>Accordion 2</span>
           </template>
 
-           <p>Content 2</p>
+          <p>Content 2</p>
         </AccordionItem>
 
         <AccordionItem value="item-3">
@@ -86,7 +86,7 @@
             <span>Accordion 3</span>
           </template>
 
-            <p>Content 3</p>
+          <p>Content 3</p>
         </AccordionItem>
       </Accordion>
     </div>

--- a/demo/src/views/Accordion.vue
+++ b/demo/src/views/Accordion.vue
@@ -24,7 +24,7 @@ const items: AccordionItem[] = [
     label: 'Item 1',
     content: 'Content for item 1',
     iconProps: { name: 'star', source: 'heroicons', type: 'solid', class: 'h-4 w-4' },
-    items : [
+    items: [
       {
         label: 'Item 1.1',
         content: 'Content for item 1.1',

--- a/src/components/accordion/Accordion.vue
+++ b/src/components/accordion/Accordion.vue
@@ -7,11 +7,14 @@
 <script setup lang="ts">
 import { Accordion as ShadcnAccordion } from '@geonative/ui/shadcn/ui/accordion';
 
-const props = withDefaults(defineProps<{
-  multiple?: boolean;
-  collapsible?: boolean;
-}>(), {
-  multiple: false,
-  collapsible: false,
-});
+const props = withDefaults(
+  defineProps<{
+    multiple?: boolean;
+    collapsible?: boolean;
+  }>(),
+  {
+    multiple: false,
+    collapsible: false,
+  }
+);
 </script>

--- a/src/components/accordion/Accordion.vue
+++ b/src/components/accordion/Accordion.vue
@@ -9,12 +9,7 @@
         <div>
           {{ item.content }}
         </div>
-        <Accordion
-          v-if="item.items"
-          :items="item.items"
-          :multiple="props.multiple"
-          :collapsible="props.collapsible"
-        />
+        <Accordion v-if="item.items" :items="item.items" :multiple="props.multiple" :collapsible="props.collapsible" />
       </ShadcnAccordionContent>
     </ShadcnAccordionItem>
   </ShadcnAccordion>

--- a/src/components/accordion/Accordion.vue
+++ b/src/components/accordion/Accordion.vue
@@ -6,9 +6,11 @@
 
 <script setup lang="ts">
 import { Accordion as ShadcnAccordion } from '@geonative/ui/shadcn/ui/accordion';
-import type { AccordionProps } from '@geonative/ui/types/accordion';
 
-const props = withDefaults(defineProps<AccordionProps>(), {
+const props = withDefaults(defineProps<{
+  multiple?: boolean;
+  collapsible?: boolean;
+}>(), {
   multiple: false,
   collapsible: false,
 });

--- a/src/components/accordion/Accordion.vue
+++ b/src/components/accordion/Accordion.vue
@@ -6,7 +6,15 @@
         {{ item.label }}
       </ShadcnAccordionTrigger>
       <ShadcnAccordionContent>
-        {{ item.content }}
+        <div>
+          {{ item.content }}
+        </div>
+        <Accordion
+          v-if="item.items"
+          :items="item.items"
+          :multiple="props.multiple"
+          :collapsible="props.collapsible"
+        />
       </ShadcnAccordionContent>
     </ShadcnAccordionItem>
   </ShadcnAccordion>

--- a/src/components/accordion/Accordion.vue
+++ b/src/components/accordion/Accordion.vue
@@ -1,0 +1,29 @@
+<template>
+  <ShadcnAccordion :type="props.multiple ? 'multiple' : 'single'" class="w-full" :collapsible="props.collapsible">
+    <ShadcnAccordionItem v-for="(item, index) in props.items" :key="index" :value="item.label">
+      <ShadcnAccordionTrigger class="flex items-center">
+        <Icon v-if="item.iconProps" v-bind="item.iconProps" />
+        {{ item.label }}
+      </ShadcnAccordionTrigger>
+      <ShadcnAccordionContent>
+        {{ item.content }}
+      </ShadcnAccordionContent>
+    </ShadcnAccordionItem>
+  </ShadcnAccordion>
+</template>
+
+<script setup lang="ts">
+import {
+  Accordion as ShadcnAccordion,
+  AccordionItem as ShadcnAccordionItem,
+  AccordionTrigger as ShadcnAccordionTrigger,
+  AccordionContent as ShadcnAccordionContent,
+} from '@geonative/ui/shadcn/ui/accordion';
+import type { AccordionProps } from '@geonative/ui/types/accordion';
+import { Icon } from '@geonative/ui/components';
+
+const props = withDefaults(defineProps<AccordionProps>(), {
+  multiple: false,
+  collapsible: false,
+});
+</script>

--- a/src/components/accordion/Accordion.vue
+++ b/src/components/accordion/Accordion.vue
@@ -1,29 +1,12 @@
 <template>
   <ShadcnAccordion :type="props.multiple ? 'multiple' : 'single'" class="w-full" :collapsible="props.collapsible">
-    <ShadcnAccordionItem v-for="(item, index) in props.items" :key="index" :value="item.label">
-      <ShadcnAccordionTrigger class="flex items-center">
-        <Icon v-if="item.iconProps" v-bind="item.iconProps" />
-        {{ item.label }}
-      </ShadcnAccordionTrigger>
-      <ShadcnAccordionContent>
-        <div>
-          {{ item.content }}
-        </div>
-        <Accordion v-if="item.items" :items="item.items" :multiple="props.multiple" :collapsible="props.collapsible" />
-      </ShadcnAccordionContent>
-    </ShadcnAccordionItem>
+    <slot />
   </ShadcnAccordion>
 </template>
 
 <script setup lang="ts">
-import {
-  Accordion as ShadcnAccordion,
-  AccordionItem as ShadcnAccordionItem,
-  AccordionTrigger as ShadcnAccordionTrigger,
-  AccordionContent as ShadcnAccordionContent,
-} from '@geonative/ui/shadcn/ui/accordion';
+import { Accordion as ShadcnAccordion } from '@geonative/ui/shadcn/ui/accordion';
 import type { AccordionProps } from '@geonative/ui/types/accordion';
-import { Icon } from '@geonative/ui/components';
 
 const props = withDefaults(defineProps<AccordionProps>(), {
   multiple: false,

--- a/src/components/accordion/AccordionItem.vue
+++ b/src/components/accordion/AccordionItem.vue
@@ -1,0 +1,19 @@
+<template>
+  <ShadcnAccordionItem :value="generateRandomKey()">
+    <ShadcnAccordionTrigger>
+      <slot name="title" />
+    </ShadcnAccordionTrigger>
+    <ShadcnAccordionContent>
+      <slot />
+    </ShadcnAccordionContent>
+  </ShadcnAccordionItem>
+</template>
+
+<script setup lang="ts">
+import {
+  AccordionItem as ShadcnAccordionItem,
+  AccordionTrigger as ShadcnAccordionTrigger,
+  AccordionContent as ShadcnAccordionContent,
+} from '@geonative/ui/shadcn/ui/accordion';
+import { generateRandomKey } from '@geonative/ui/helpers';
+</script>

--- a/src/components/accordion/index.ts
+++ b/src/components/accordion/index.ts
@@ -1,0 +1,1 @@
+export { default as Accordion } from './Accordion.vue';

--- a/src/components/accordion/index.ts
+++ b/src/components/accordion/index.ts
@@ -1,1 +1,2 @@
 export { default as Accordion } from './Accordion.vue';
+export { default as AccordionItem } from './AccordionItem.vue';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,3 +10,4 @@ export * from './icons';
 export * from './navbar';
 export * from './theme';
 export * from './sonner';
+export * from './accordion';

--- a/src/helpers/string.ts
+++ b/src/helpers/string.ts
@@ -15,3 +15,13 @@ export function startsWithHttp(str: string) {
 export function ucfirst(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
+
+
+/**
+ * Generate a random key.
+ * @param length
+ * @return string
+ */
+export function generateRandomKey(length = 10) {
+  return Math.random().toString(36).substring(2, 2 + length);
+}

--- a/src/helpers/string.ts
+++ b/src/helpers/string.ts
@@ -16,12 +16,13 @@ export function ucfirst(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-
 /**
  * Generate a random key.
  * @param length
  * @return string
  */
 export function generateRandomKey(length = 10) {
-  return Math.random().toString(36).substring(2, 2 + length);
+  return Math.random()
+    .toString(36)
+    .substring(2, 2 + length);
 }

--- a/src/shadcn/ui/accordion/Accordion.vue
+++ b/src/shadcn/ui/accordion/Accordion.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import {
+  AccordionRoot,
+  type AccordionRootEmits,
+  type AccordionRootProps,
+  useForwardPropsEmits,
+} from 'reka-ui'
+
+const props = defineProps<AccordionRootProps>()
+const emits = defineEmits<AccordionRootEmits>()
+
+const forwarded = useForwardPropsEmits(props, emits)
+</script>
+
+<template>
+  <AccordionRoot data-slot="accordion" v-bind="forwarded">
+    <slot />
+  </AccordionRoot>
+</template>

--- a/src/shadcn/ui/accordion/AccordionContent.vue
+++ b/src/shadcn/ui/accordion/AccordionContent.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { cn } from '@geonative/ui/shadcn/lib/utils'
+import { AccordionContent, type AccordionContentProps } from 'reka-ui'
+import { computed, type HTMLAttributes } from 'vue'
+
+const props = defineProps<AccordionContentProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+</script>
+
+<template>
+  <AccordionContent
+    data-slot="accordion-content"
+    v-bind="delegatedProps"
+    class="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+  >
+    <div :class="cn('pt-0 pb-4', props.class)">
+      <slot />
+    </div>
+  </AccordionContent>
+</template>

--- a/src/shadcn/ui/accordion/AccordionItem.vue
+++ b/src/shadcn/ui/accordion/AccordionItem.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { cn } from '@geonative/ui/shadcn/lib/utils'
+import { AccordionItem, type AccordionItemProps, useForwardProps } from 'reka-ui'
+import { computed, type HTMLAttributes } from 'vue'
+
+const props = defineProps<AccordionItemProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+  <AccordionItem
+    data-slot="accordion-item"
+    v-bind="forwardedProps"
+    :class="cn('border-b last:border-b-0', props.class)"
+  >
+    <slot />
+  </AccordionItem>
+</template>

--- a/src/shadcn/ui/accordion/AccordionTrigger.vue
+++ b/src/shadcn/ui/accordion/AccordionTrigger.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { cn } from '@geonative/ui/shadcn/lib/utils'
+import { ChevronDown } from 'lucide-vue-next'
+import {
+  AccordionHeader,
+  AccordionTrigger,
+  type AccordionTriggerProps,
+} from 'reka-ui'
+import { computed, type HTMLAttributes } from 'vue'
+
+const props = defineProps<AccordionTriggerProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = computed(() => {
+  const { class: _, ...delegated } = props
+
+  return delegated
+})
+</script>
+
+<template>
+  <AccordionHeader class="flex">
+    <AccordionTrigger
+      data-slot="accordion-trigger"
+      v-bind="delegatedProps"
+      :class="
+        cn(
+          'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
+          props.class,
+        )
+      "
+    >
+      <slot />
+      <slot name="icon">
+        <ChevronDown
+          class="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200"
+        />
+      </slot>
+    </AccordionTrigger>
+  </AccordionHeader>
+</template>

--- a/src/shadcn/ui/accordion/index.ts
+++ b/src/shadcn/ui/accordion/index.ts
@@ -1,0 +1,4 @@
+export { default as Accordion } from './Accordion.vue'
+export { default as AccordionContent } from './AccordionContent.vue'
+export { default as AccordionItem } from './AccordionItem.vue'
+export { default as AccordionTrigger } from './AccordionTrigger.vue'

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss' source('../');
+@import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -110,6 +111,8 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --animate-accordion-down: accordion-down 0.2s ease-out;
+  --animate-accordion-up: accordion-up 0.2s ease-out;
 }
 
 @layer base {

--- a/src/types/accordion.ts
+++ b/src/types/accordion.ts
@@ -4,10 +4,12 @@ export interface AccordionItem {
   label: string;
   content: string;
   iconProps?: IconProps;
+  items?: AccordionItem[];
 }
 
 export interface AccordionProps {
   items: AccordionItem[];
   multiple?: boolean;
   collapsible?: boolean;
+
 }

--- a/src/types/accordion.ts
+++ b/src/types/accordion.ts
@@ -11,5 +11,4 @@ export interface AccordionProps {
   items: AccordionItem[];
   multiple?: boolean;
   collapsible?: boolean;
-
 }

--- a/src/types/accordion.ts
+++ b/src/types/accordion.ts
@@ -1,14 +1,4 @@
-import type { IconProps } from '@geonative/ui/types';
-
-export interface AccordionItem {
-  label: string;
-  content: string;
-  iconProps?: IconProps;
-  items?: AccordionItem[];
-}
-
 export interface AccordionProps {
-  items: AccordionItem[];
   multiple?: boolean;
   collapsible?: boolean;
 }

--- a/src/types/accordion.ts
+++ b/src/types/accordion.ts
@@ -1,4 +1,0 @@
-export interface AccordionProps {
-  multiple?: boolean;
-  collapsible?: boolean;
-}

--- a/src/types/accordion.ts
+++ b/src/types/accordion.ts
@@ -1,0 +1,13 @@
+import type { IconProps } from '@geonative/ui/types';
+
+export interface AccordionItem {
+  label: string;
+  content: string;
+  iconProps?: IconProps;
+}
+
+export interface AccordionProps {
+  items: AccordionItem[];
+  multiple?: boolean;
+  collapsible?: boolean;
+}


### PR DESCRIPTION
**Add `Accordion` and `AccordionItem` components using slot**

- Supports custom `title` via a named slot.
- Fully slot-based, allowing content like icons, text, and buttons.
- Accepts `multiple` and `collapsible` props for behavior control.

